### PR TITLE
Fix tests - this requires to drop Python 2.6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 env:
-    - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py33
 install:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 4.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Dropped support for Python 2.6.
 
 
 4.0.0a1 (2013-02-25)

--- a/src/zope/generations/tests/test_generations.py
+++ b/src/zope/generations/tests/test_generations.py
@@ -25,6 +25,11 @@ checker = renormalizing.RENormalizing([
      r"\1"),
     (re.compile('u(".*?")'),
      r"\1"),
+    # Python 2 bytes has no "b".
+    (re.compile("b('.*?')"),
+     r"\1"),
+    (re.compile('b(".*?")'),
+     r"\1"),
     ])
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py26,py27,py33
+    py27,
+    py33,
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 2.6 is no longer supported by setuptools.